### PR TITLE
react_crud_dataへのコメントのCRUDを追加

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,0 +1,72 @@
+class CommentsController < ApplicationController
+  before_action :load_comment, only: %i[update destroy]
+
+  def index
+    react_crud_datum = ReactCrudDatum.find(params[:react_crud_datum_id])
+    @comments = react_crud_datum.comments.order(updated_at: :desc)
+    respond_to do |format|
+      format.json { render json: @comments }
+    end
+  end
+
+  def create
+    react_crud_datum = ReactCrudDatum.find(params[:react_crud_datum_id])
+    @comment = react_crud_datum.comments.new(comment_params)
+    if @comment.save
+      respond_to do |format|
+        format.json do
+          render json: { registration: 'Ajaxによるコメントの追加が完了しました。',
+                         id: @comment.id,
+                         description: @comment.description,
+                         updated_at: @comment.updated_at }
+        end
+      end
+    else
+      respond_to do |format|
+        format.json do
+          render json: { id: 'error',
+                         registration: 'Ajaxによるコメントの追加に失敗しました。' }
+        end
+      end
+    end
+  end
+
+  def update
+    respond_to do |format|
+      if @comment.update(comment_params)
+        format.json do
+          render json: { registration: 'Ajaxによるコメントの更新に成功しました。' }
+        end
+      else
+        format.json do
+          render json: { registration: 'Ajaxによるコメントの更新に失敗しました。' }
+        end
+      end
+    end
+  end
+
+  def destroy
+    respond_to do |format|
+      if @comment.destroy
+        format.json do
+          render json: { registration: 'Ajaxによるコメントの削除に成功しました。' }
+        end
+      else
+        format.json do
+          render json: { registration: 'Ajaxによるコメントの削除に失敗しました。' }
+        end
+      end
+    end
+  end
+
+  private
+
+  def comment_params
+    params.require(:comment).permit(:description)
+  end
+
+  def load_comment
+    react_curd_datum = ReactCrudDatum.find(params[:react_crud_datum_id])
+    @comment = react_curd_datum.comments.find(params[:id])
+  end
+end

--- a/app/controllers/react_crud_data_controller.rb
+++ b/app/controllers/react_crud_data_controller.rb
@@ -1,12 +1,20 @@
 # frozen_string_literal: true
 
 class ReactCrudDataController < ApplicationController
-  before_action :set_datum, only: %i[update destroy]
+  before_action :set_datum, only: %i[update destroy show]
   def index
     @data = ReactCrudDatum.all.order(updated_at: :desc)
     respond_to do |format|
       format.html
       format.json { render json: @data }
+    end
+  end
+
+  def show
+    @id = params[:id]
+    respond_to do |format|
+      format.html
+      format.json { render json: @datum }
     end
   end
 

--- a/app/javascript/packs/comment.jsx
+++ b/app/javascript/packs/comment.jsx
@@ -1,0 +1,237 @@
+import 'react-app-polyfill/ie9'
+import 'react-app-polyfill/stable'
+
+import React from 'react'
+import ReactDOM from 'react-dom'
+
+import {format} from 'date-fns'
+import ja from 'date-fns/locale/ja'
+
+import 'formdata-polyfill'
+
+class Comment extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      error: null,
+      isLoaded: null,
+      item: null,
+      description: '',
+      status: 'ここにAjaxに関するメッセージが表示されます。',
+      comments: [],
+      mode: []
+    }
+  }
+
+  componentDidMount() {
+    fetch(`http://localhost:3000/react_crud_data/${this.props.id}.json`)
+      .then(res => res.json())
+      .then((result) => {
+          this.setState({
+            item: result,
+          });
+        },
+        (error) => {
+          this.setState({
+            error
+          })
+        }
+      )
+
+    fetch(`http://localhost:3000/react_crud_data/${this.props.id}/comments.json`)
+      .then(res => res.json())
+      .then((result) => {
+        const mode = Array(result.length).fill(null)
+        this.setState({
+          mode: mode,
+          comments: result,
+          isLoaded: true,
+        })
+      },
+        (error) => {
+          this.setState({
+            isLoaded: true,
+            error
+          })
+        }
+      )
+  }
+
+  run_ajax(method, url, data) {
+    fetch(url, {
+      method: method,
+      body: JSON.stringify(data),
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').getAttribute('content')
+      }
+    })
+      .then(res => res.json())
+      .then((result) => {
+        this.setState((state) => {
+          state.status = 'サーバーからのメッセージ(' +
+            format(new Date(), 'yyyy年MM月dd日(iiii) HH:mm:ss', {locale: ja}) + ') :' +
+            result.registration
+
+          if (result.id) {
+            if (result.id === 'error') {
+              return { status: state.status }
+            } else {
+              state.comments.unshift({
+                id: result.id,
+                description: result.description,
+                updated_at: result.updated_at
+              })
+              state.mode.unshift(false)
+              return { status: state.status, comments: state.comments, mode: state.mode }
+            }
+          } else {
+            return { status: state.status }
+          }
+        })
+      }, (error) => {
+        this.setState((state) => {
+          state.status = error.message;
+          return { state: state.status }
+        })
+    })
+      .catch((error) => {
+        this.setState((state) => {
+          state.status = error.message;
+          return { state: state.status }
+        })
+      })
+  }
+
+  handleInsert(event) {
+    this.setState((state) => {
+      if (state.description) {
+        this.run_ajax("POST",
+          `http://localhost:3000/react_crud_data/${this.props.id}/comments`,
+          { comment: { description: state.description } })
+        state.description = ''
+        return { comments: state.comments }
+      }
+    })
+    event.preventDefault()
+  }
+
+  handleDescriptionEdit(event) {
+    const value = event.target.value;
+    this.setState((state) => {
+      state.description = value;
+      return { description: state.description }
+    })
+  }
+
+  handleModeChange(index, event) {
+    this.setState((state) => {
+      state.mode[index] = !state.mode[index];
+      return { mode: state.mode }
+    });
+    event.preventDefault();
+  }
+
+  handleDelete(index, id, event) {
+    this.setState((state) => {
+      state.comments.splice(index, 1);
+      state.mode.splice(index, 1);
+
+      this.run_ajax("DELETE",
+        `http://localhost:3000/react_crud_data/${this.props.id}/comments/${id}`,
+        {});
+      return { comments: state.comments, mode: state.mode }
+    })
+    event.preventDefault();
+  }
+
+  handleUpdate(index, id, event) {
+    const form_data = new FormData(event.target);
+
+    this.setState((state) => {
+      const txt_description = form_data.get('txt_description');
+      if (txt_description && !(state.comments[index].description === txt_description)) {
+        state.comments[index].description = txt_description
+        state.comments[index].updated_at = new Date();
+
+        this.run_ajax("PUT",
+          `http://localhost:3000/react_crud_data/${this.props.id}/comments/${id}`,
+          { comment: { description: txt_description } })
+
+        return { comments: state.comments }
+      }
+    })
+
+    this.handleModeChange(index, event)
+  }
+
+  render() {
+    const { error, isLoaded, item, comments, mode } = this.state;
+
+    if(error) {
+      return <div>Error: {error.message}</div>;
+    } else if (!isLoaded) {
+      return <div>Loading...</div>;
+    } else {
+      return (
+        <div>
+          <div className="card w-100 mt-3">
+            <div className="card-body">
+              <h3 className="card-title">{item.name}</h3>
+              <div className="card-text">{item.comment}</div>
+            </div>
+          </div>
+          <div className="mt-3">
+            <h3>コメントを投稿</h3>
+            <form onSubmit={ this.handleInsert.bind(this) }>
+              <input type="text" value={ this.state.description } name="txt_description" className="form-control" placeholder="コメント" onChange={ this.handleDescriptionEdit.bind(this) }/>
+              <input type="submit" value="登録" className="btn btn-primary"/>
+            </form>
+          </div>
+          <div className="mt-3">
+            <h3>コメント一覧</h3>
+            <ul className="list-group list-group-flush">
+              { comments.map((comment, index) => {
+                if (!mode[index]) {
+                  return (
+                    <li className="list-group-item" key={index}>
+                      <p className="mb-0">{ comment.description }</p>
+                      <p className="mb-0">{ format(new Date(Date.parse(comment.updated_at)), 'yyyy年MM月dd日(iiii) HH:mm:ss', { locale: ja }) }</p>
+                      <form>
+                        <div style={ { textAlign: 'right' } }>
+                          <input type="submit" value="編集" className="btn btn-primary" onClick={ this.handleModeChange.bind(this, index) }/>
+                          <input type="submit" value="削除" className="btn btn-danger" onClick={ this.handleDelete.bind(this, index, comment.id) }/>
+                        </div>
+                      </form>
+                    </li>
+                  )
+                } else {
+                  return (
+                    <li className="list-group-item" key={index}>
+                      <form onSubmit={this.handleUpdate.bind(this, index, comment.id)}>
+                        <input type="text" defaultValue={ comment.description } name="txt_description" className="mb-0 form-control"/>
+                        <div style={ { textAlign: 'right' } }>
+                          <input type="submit" value="キャンセル" className="btn btn-secondary" onClick={ this.handleModeChange.bind(this, index) }/>
+                          <input type="submit" value="更新" className="btn btn-primary"/>
+                        </div>
+                      </form>
+                    </li>
+                  )
+                }
+              })}
+            </ul>
+          </div>
+        </div>
+      )
+    }
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const itemId = document.getElementById("itemId").value
+
+  ReactDOM.render(
+    <Comment id={itemId}/>,
+    document.getElementById('root')
+  )
+})

--- a/app/javascript/packs/comment.jsx
+++ b/app/javascript/packs/comment.jsx
@@ -8,6 +8,7 @@ import {format} from 'date-fns'
 import ja from 'date-fns/locale/ja'
 
 import 'formdata-polyfill'
+import StatusMessage from "./status_message";
 
 class Comment extends React.Component {
   constructor(props) {
@@ -175,6 +176,7 @@ class Comment extends React.Component {
     } else {
       return (
         <div>
+          <StatusMessage status={this.state.status} />
           <div className="card w-100 mt-3">
             <div className="card-body">
               <h3 className="card-title">{item.name}</h3>

--- a/app/javascript/packs/react_crud.jsx
+++ b/app/javascript/packs/react_crud.jsx
@@ -164,7 +164,7 @@ class ReactCrudComponent extends React.Component {
       },
         (error) => {
         this.setState({
-          isLoaded: false,
+          isLoaded: true,
           error
         })
         }

--- a/app/javascript/packs/react_crud.jsx
+++ b/app/javascript/packs/react_crud.jsx
@@ -151,7 +151,7 @@ class ReactCrudComponent extends React.Component {
   }
 
   componentDidMount() {
-    fetch("http://localhost:3000/react_crud_data/index.json")
+    fetch("http://localhost:3000/react_crud_data.json")
       .then(res => res.json())
       .then((result) => {
         const mode = Array(result.length).fill(null)

--- a/app/javascript/packs/react_crud.jsx
+++ b/app/javascript/packs/react_crud.jsx
@@ -202,7 +202,10 @@ class ReactCrudComponent extends React.Component {
                 return (
                   <div className="card" key={index}>
                     <div className="card-header">
-                      {item.name} <br/>{format(new Date(Date.parse(item.updated_at)), 'yyyy年MM月dd日(iiii) HH:mm:ss', {locale: ja})}
+                      <a href={`/react_crud_data/${item.id}`}>{item.name}</a>
+                      <div>
+                        {format(new Date(Date.parse(item.updated_at)), 'yyyy年MM月dd日(iiii) HH:mm:ss', {locale: ja})}
+                      </div>
                     </div>
                     <div className="card-body">
                       {item.comment}

--- a/app/javascript/packs/react_crud.jsx
+++ b/app/javascript/packs/react_crud.jsx
@@ -9,6 +9,7 @@ import {format} from 'date-fns'
 import ja from 'date-fns/locale/ja'
 
 import 'formdata-polyfill'
+import StatusMessage from "./status_message";
 
 class ReactCrudComponent extends React.Component {
   constructor(props) {
@@ -181,11 +182,7 @@ class ReactCrudComponent extends React.Component {
     } else {
       return (
         <div>
-          <p />
-          <div className="fixed-bottom bg-dark text-white" style={{opacity: 0.55}}>
-            <span>&nbsp;&nbsp;</span>
-            <span>{this.state.status}</span>
-          </div>
+          <StatusMessage status={this.state.status} />
           <h3>投稿</h3>
           <p />
           <form onSubmit={this.handleInsert.bind(this)}>

--- a/app/javascript/packs/status_message.jsx
+++ b/app/javascript/packs/status_message.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+function StatusMessage(props) {
+  return (
+    <div className="fixed-bottom bg-dark text-white" style={{opacity: 0.55}}>
+      <span>&nbsp;&nbsp;</span>
+      <span>{props.status}</span>
+    </div>
+  )
+}
+
+export default StatusMessage;

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,2 @@
+class Comment < ApplicationRecord
+end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,2 +1,3 @@
 class Comment < ApplicationRecord
+  belongs_to :react_crud_data, class_name: 'ReactCrudDatum'
 end

--- a/app/models/react_crud_datum.rb
+++ b/app/models/react_crud_datum.rb
@@ -1,4 +1,6 @@
 class ReactCrudDatum < ApplicationRecord
   validates :name, length: { maximum: 20 }, presence: true
   validates :comment, length: { maximum: 140 }, presence: true
+
+  has_many :comments, foreign_key: 'react_crud_data_id', dependent: :destroy
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,7 +13,9 @@
 
   <body>
     <div class="navbar navbar-expand-md navbar-light bg-primary">
-      <div class="navbar-brand text-white"><%= "Rails + React + AjaxでCRUDのサンプルプロジェクト" %></div>
+      <div class="navbar-brand">
+        <%= link_to "Rails + React + AjaxでCRUDのサンプルプロジェクト", root_path, class: "text-white" %>
+      </div>
       <ul class="navbar-nav ml-auto">
         <li class="nav-item">
           <%= link_to "すべて初期化", new_react_crud_datum_path, class: "nav-link", style: "color: #fff;" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,7 +9,6 @@
 
     <%= stylesheet_link_tag 'application', media: 'all' %>
     <%= javascript_pack_tag 'application' %>
-    <%= javascript_pack_tag 'react_crud' %>
   </head>
 
   <body>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,7 +17,7 @@
       <div class="navbar-brand text-white"><%= "Rails + React + AjaxでCRUDのサンプルプロジェクト" %></div>
       <ul class="navbar-nav ml-auto">
         <li class="nav-item">
-          <%= link_to "すべて初期化", new_react_crud_data_path, class: "nav-link", style: "color: #fff;" %>
+          <%= link_to "すべて初期化", new_react_crud_datum_path, class: "nav-link", style: "color: #fff;" %>
         </li>
       </ul>
     </div>

--- a/app/views/react_crud_data/index.html.erb
+++ b/app/views/react_crud_data/index.html.erb
@@ -1,1 +1,2 @@
+<%= javascript_pack_tag 'react_crud' %>
 <div id="root"></div>

--- a/app/views/react_crud_data/show.html.erb
+++ b/app/views/react_crud_data/show.html.erb
@@ -1,0 +1,1 @@
+<div id="root"></div>

--- a/app/views/react_crud_data/show.html.erb
+++ b/app/views/react_crud_data/show.html.erb
@@ -1,1 +1,3 @@
+<%= hidden_field_tag "itemId", @id %>
+<%= javascript_pack_tag 'comment' %>
 <div id="root"></div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,4 @@
 Rails.application.routes.draw do
   root to: 'react_crud_data#index'
-  get    'react_crud_data/index'
-  get    'react_crud_data/new',  to: 'react_crud_data#new',     as: 'new_react_crud_data'
-  post   'react_crud_data',      to: 'react_crud_data#create'
-  put    'react_crud_data/:id',  to: 'react_crud_data#update'
-  delete 'react_crud_data/:id',  to: 'react_crud_data#destroy'
+  resources :react_crud_data, except: [:edit]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
   root to: 'react_crud_data#index'
-  resources :react_crud_data, except: [:edit]
+  resources :react_crud_data, except: [:edit] do
+    resources :comments, only: %i[index create update destroy]
+  end
 end

--- a/db/migrate/20200616063533_create_comments.rb
+++ b/db/migrate/20200616063533_create_comments.rb
@@ -1,0 +1,10 @@
+class CreateComments < ActiveRecord::Migration[6.0]
+  def change
+    create_table :comments do |t|
+      t.text :description
+      t.references :react_crud_data
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_16_001911) do
+ActiveRecord::Schema.define(version: 2020_06_16_063533) do
+
+  create_table "comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.text "description"
+    t.bigint "react_crud_data_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["react_crud_data_id"], name: "index_comments_on_react_crud_data_id"
+  end
 
   create_table "react_crud_data", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name"


### PR DESCRIPTION
## 概要

react_crud_dataへのコメントのCRUDを追加。
また、ページ下部のメッセージ表示部分をコンポーネントに分割しました。

## やったこと

- react_crud_data_controller.rbにshowアクションを追加し、詳細ページを追加
- Commentモデルを作成
- Commentクラスコンポーネントを追加し、react_crud_dataに紐づくコメントを表示し、コメントの投稿・削除・更新機能を追加
- トップページの投稿一覧に各投稿の詳細ページへのリンクを追加
- ヘッダーのタイトルからトップページに戻れるようにリンクを追加
- ページ下部に表示されるstatusメッセージをコンポーネントに分割し投稿一覧ページと詳細ページで表示されるようにした

[![Image from Gyazo](https://i.gyazo.com/e9707b4e0fe3bf0848099851bd3a8c9f.png)](https://gyazo.com/e9707b4e0fe3bf0848099851bd3a8c9f)

## やらなかったこと

- react_crud_dataを簡単に初期化できるように、プチモンテのチュートリアルではreact_crud_controller.rbのnewアクションにてreact_crud_dataテーブルをTRUNCATEしたのちreact_crud_data_bksからデータを挿入しているのですが、紐づくコメントについては削除されずに残ってしまいます。今回の課題の範疇とは離れているかと思い、そのままにしていますが、対応する必要があるのであれば修正したいと思います。